### PR TITLE
git.io->cloudposse.tools update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ GEODESIC_INSTALL_PATH ?= /usr/local/bin
 export INSTALL_PATH ?= $(GEODESIC_INSTALL_PATH)
 export SCRIPT = $(INSTALL_PATH)/$(APP_NAME)
 
--include $(shell curl -sSL -o .build-harness "https://git.io/build-harness"; echo .build-harness)
+-include $(shell curl -sSL -o .build-harness "https://cloudposse.tools/build-harness"; echo .build-harness)
 
 ## Initialize build-harness, install deps, build docker container, install wrapper script and run shell
 all: init deps build install run


### PR DESCRIPTION
## what and why 
Change all references to `git.io/build-harness` into `cloudposse.tools/build-harness`, since `git.io` redirects will stop working on April 29th, 2022.

## References
- DEV-143